### PR TITLE
on key generation error signal registration abandonment to the server

### DIFF
--- a/routes/webauthn.js
+++ b/routes/webauthn.js
@@ -77,6 +77,8 @@ router.post('/response', (request, response) => {
     if(!request.body       || !request.body.id
     || !request.body.rawId || !request.body.response
     || !request.body.type  || request.body.type !== 'public-key' ) {
+        request.session.challenge = undefined;
+        request.session.username = undefined;
         response.json({
             'status': 'failed',
             'message': 'Response missing one or more of id/rawId/response/type fields, or type is not public-key!'

--- a/static/js/webauthn.auth.js
+++ b/static/js/webauthn.auth.js
@@ -64,7 +64,12 @@ $('#register').submit(function(event) {
                 alert(`Server responed with error. The message is: ${response.message}`);
             }
         })
-        .catch((error) => alert(error))
+        .catch((error) => {
+            //on navigator.credentials.create error, send empty (aka invalid) object to the server to signal the error
+            //the server then needs to clear its session variables
+            sendWebAuthnResponse({}); 
+            alert(error)
+        })
 })
 
 let getGetAssertionChallenge = (formBody) => {


### PR DESCRIPTION
When navigator.credentials.get() throws an error, the server clears session variables (challenge and username in the specific demo). In webauthn.authn.js (in static), line 70 we send a sendWebAuthnResponse({}) with an empty object. The server (webauthn.js file in routes) makes checks for the presence of the fields and before responding with a status error in clears session variables.

For example, the navigator.credentials.get() can throw an error when clicking 'cancel' on the box that appears to select the authenticator. 